### PR TITLE
Remove a few cp commands

### DIFF
--- a/zugzug-sys/Cargo.toml
+++ b/zugzug-sys/Cargo.toml
@@ -9,6 +9,7 @@ links = "pubnub_callback"
 
 [build-dependencies]
 bindgen = "*"
+fs_extra = "1.1"
 regex = "1.1.2"
 ruplacer = "0.4.1"
 

--- a/zugzug-sys/build.rs
+++ b/zugzug-sys/build.rs
@@ -22,10 +22,11 @@ fn main() {
 
   let upstream_build_dir_posix = upstream_build_dir.join("posix");
 
-  let mut copy_options = CopyOptions::new();
-  copy_options.copy_inside = true;
-  copy_options.overwrite = true;
-  copy_items(&vec!["vendor/c-core"], &upstream_build_dir.display().to_string(), &copy_options).unwrap();
+  copy_items(&vec!["vendor/c-core"], &upstream_build_dir.display().to_string(), &CopyOptions {
+    copy_inside: true,
+    overwrite: true,
+    ..CopyOptions::new()
+  }).unwrap();
 
   DirectoryPatcher::new(upstream_build_dir_posix.join("posix.mk"), Default::default())
     .patch(&Query::Regex(


### PR DESCRIPTION
I tried to work on removing a few `Command`s as requested in the todo for the build.rs in sys. I wasn't able to get the `make` command, but I did grab the `cp`s.