### PR TITLE
single client with futures api

### DIFF
--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -36,7 +36,7 @@ fn main() {
   let channel = opt.channel;
   let group = opt.group;
 
-  let task = client.unwrap().subscribe::<Stuff>(&channel, &group).unwrap();
+  let task = client.subscribe::<Stuff>(&channel, &group);
 
   tokio::run(task.for_each(|v| {
     match v {
@@ -46,5 +46,5 @@ fn main() {
     Ok(())
   }));
 
-  println!("how did we get here?");
+  panic!("The task should never finish");
 }

--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -26,21 +26,25 @@ struct Stuff {
 
 fn main() {
   let opt = Opt::from_args();
-  let (tx, rx) = futures::sync::mpsc::channel::<Result<Stuff, ClientError>>(4096);
-  let _client = SubscribeClient::start(
-    ClientConfig {
-      auth_key: opt.auth_key,
-      publish_key: opt.publish_key,
-      subscribe_key: opt.subscribe_key,
-      channel: opt.channel,
-      group: opt.group,
-      client_uuid: opt.client_uuid,
-    },
-    tx,
-  );
+  let client = Client::new(ClientConfig {
+    auth_key: opt.auth_key,
+    publish_key: opt.publish_key,
+    subscribe_key: opt.subscribe_key,
+    client_uuid: opt.client_uuid,
+  });
 
-  tokio::run(rx.for_each(|v| {
-    println!("whoa! a message! {:?}", v);
+  let channel = opt.channel;
+  let group = opt.group;
+
+  let task = client.unwrap().subscribe::<Stuff>(&channel, &group).unwrap();
+
+  tokio::run(task.for_each(|v| {
+    match v {
+      Ok(i) => println!("whoa! a message! {:?}", i),
+      Err(e) => println!("error {:?}", e),
+    }
     Ok(())
-  }))
+  }));
+
+  println!("how did we get here?");
 }

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -31,8 +31,7 @@ fn main() {
     publish_key: opt.publish_key,
     subscribe_key: opt.subscribe_key,
     client_uuid: opt.client_uuid,
-  })
-  .unwrap();
+  });
 
   let channel = opt.channel;
   let group = opt.group;
@@ -48,7 +47,6 @@ fn main() {
           message: format!("#{}", i),
         },
       )
-      .unwrap()
       .wait()
       .map_err(|e| println!("send error {:?}", e))
       .ok();

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -26,23 +26,29 @@ struct Stuff {
 
 fn main() {
   let opt = Opt::from_args();
-  let mut client = PublishClient::new(ClientConfig {
+  let client = Client::new(ClientConfig {
     auth_key: opt.auth_key,
     publish_key: opt.publish_key,
     subscribe_key: opt.subscribe_key,
-    channel: opt.channel,
-    group: opt.group,
     client_uuid: opt.client_uuid,
   })
   .unwrap();
+
+  let channel = opt.channel;
+  let group = opt.group;
 
   let mut i = 0;
   loop {
     println!("sending");
     client
-      .publish(Stuff {
-        message: format!("#{}", i),
-      })
+      .publish(
+        &channel,
+        &group,
+        Stuff {
+          message: format!("#{}", i),
+        },
+      )
+      .unwrap()
       .wait()
       .map_err(|e| println!("send error {:?}", e))
       .ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,20 +3,25 @@ use futures::sync::mpsc::{Receiver, Sender};
 use futures::task::Task;
 use futures::{Async, Future};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
 use std::ffi::CString;
 
 use zugzug_sys::callback::*;
 
-// TODO: see if we can pull out the channel stuff, etc. and subscribe to multiple channels; we probably should just return a `Subscription` which implements `Stream`.  This would also allow us to have a single client that produces subscription `Stream`s and publish `Future`s.
 #[derive(Clone, Debug)]
 pub struct ClientConfig {
   pub auth_key: String,
   pub publish_key: String,
   pub subscribe_key: String,
-  pub channel: String,
-  pub group: String,
   pub client_uuid: String,
+}
+
+struct ChannelConfig {
+  auth_key: CString,
+  publish_key: CString,
+  subscribe_key: CString,
+  client_uuid: CString,
+  channel: CString,
+  group: CString,
 }
 
 struct SubscribeUserData<T> {
@@ -24,17 +29,134 @@ struct SubscribeUserData<T> {
   tx: Sender<Result<T, ClientError>>,
 }
 
-pub struct SubscribeClient<T> {
+pub struct Client {
+  auth_key: CString,
+  publish_key: CString,
+  subscribe_key: CString,
+  client_uuid: CString,
+}
+
+impl Client {
+  pub fn new(config: ClientConfig) -> Result<Self, std::ffi::NulError> {
+    let auth_key = CString::new(config.auth_key)?;
+    let publish_key = CString::new(config.publish_key)?;
+    let subscribe_key = CString::new(config.subscribe_key)?;
+    let client_uuid = CString::new(config.client_uuid)?;
+    Ok(Self {
+      auth_key,
+      publish_key,
+      subscribe_key,
+      client_uuid,
+    })
+  }
+
+  pub fn subscribe<'a, T: Send + Sync + Deserialize<'a>>(
+    &self,
+    channel: &str,
+    group: &str,
+  ) -> Result<Subscription<T>, std::ffi::NulError> {
+    let channel_c = CString::new(channel)?;
+    let group_c = CString::new(group)?;
+
+    let config = ChannelConfig {
+      auth_key: self.auth_key.clone(),
+      publish_key: self.publish_key.clone(),
+      subscribe_key: self.subscribe_key.clone(),
+      client_uuid: self.client_uuid.clone(),
+      channel: channel_c,
+      group: group_c,
+    };
+
+    Ok(Subscription::new(config))
+  }
+
+  pub fn publish<T: Serialize>(
+    &self,
+    channel: &str,
+    group: &str,
+    body: T,
+  ) -> Result<PublishFuture, std::ffi::NulError> {
+    let channel_c = CString::new(channel)?;
+    let group_c = CString::new(group)?;
+
+    let config = ChannelConfig {
+      auth_key: self.auth_key.clone(),
+      publish_key: self.publish_key.clone(),
+      subscribe_key: self.subscribe_key.clone(),
+      client_uuid: self.client_uuid.clone(),
+      channel: channel_c,
+      group: group_c,
+    };
+
+    // TODO: we may want a context pool as each context consumes significant resources.
+    Ok(PublishFuture::new(config, body))
+  }
+}
+
+pub struct Subscription<T> {
   ctx: *mut pubnub_t,
+  rx: Receiver<Result<T, ClientError>>,
   // We hold on to this so that we can free the memory later.
   user_data: *mut SubscribeUserData<T>,
-  // We pass refs of these to C land.  We keep them around here so they will not be freed until the `Client` is dropped.
-  _channel: CString,
+  // We pass refs of these to C land.  We keep them around here so they will not be freed until the `Subscription` is dropped.
   _auth_key: CString,
   _publish_key: CString,
   _subscribe_key: CString,
-  _group: CString,
   _client_uuid: CString,
+  _channel: CString,
+  _group: CString,
+}
+
+// The pointers in `Subscription` are thread-safe, so we can implement this.
+unsafe impl<T> Send for Subscription<T> {}
+
+impl<'a, T: Send + Sync + Deserialize<'a>> Subscription<T> {
+  fn new(config: ChannelConfig) -> Self {
+    let auth_key = config.auth_key;
+    let publish_key = config.publish_key;
+    let subscribe_key = config.subscribe_key;
+    let client_uuid = config.client_uuid;
+    let channel = config.channel;
+    let group = config.group;
+
+    let (tx, rx) = futures::sync::mpsc::channel::<Result<T, ClientError>>(10);
+
+    let user_data = Box::into_raw(Box::new(SubscribeUserData {
+      tx,
+      channel: channel.clone(), // TODO: can this just be a reference?
+    }));
+
+    let ctx = unsafe {
+      let ctx = pubnub_alloc();
+      pubnub_init(ctx, publish_key.as_ptr(), subscribe_key.as_ptr());
+      pubnub_set_uuid(ctx, client_uuid.as_ptr());
+      pubnub_set_auth(ctx, auth_key.as_ptr());
+      pubnub_register_callback(ctx, Some(subscribe_callback::<T>), user_data as *mut std::ffi::c_void);
+      pubnub_subscribe(ctx, channel.as_ptr(), std::ptr::null()); // TODO: technically we shouldn't call this line until the stream gets polled the first time.
+      ctx
+    };
+
+    Self {
+      ctx,
+      rx,
+      _channel: channel,
+      _auth_key: auth_key,
+      _publish_key: publish_key,
+      _subscribe_key: subscribe_key,
+      _group: group,
+      _client_uuid: client_uuid,
+      user_data,
+    }
+  }
+}
+
+impl<T: std::fmt::Debug> Stream for Subscription<T> {
+  type Item = Result<T, ClientError>;
+  type Error = ();
+
+  fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+    self.rx.poll()
+  }
 }
 
 unsafe extern "C" fn subscribe_callback<'a, T: Deserialize<'a>>(
@@ -62,103 +184,19 @@ unsafe extern "C" fn subscribe_callback<'a, T: Deserialize<'a>>(
       .try_send(res)
       .map_err(|e| println!("subscribe callback unable to send {:?}", e))
       .ok();
+    // We shouldn't need to notify, because that is taken care of by the channel.
   }
 
   // TODO: verify that we are happy with this here.  PubNub docs suggest that it is ok to do operations like this inside of a callback, but not recommended (as it can make debugging harder).  Our use case is simple (a loop), so maybe we're ok?
   pubnub_subscribe(pb, ud.channel.as_ptr(), std::ptr::null());
 }
 
-impl<'a, T: Send + Sync + Deserialize<'a>> SubscribeClient<T> {
-  /// Starts a client, subscribed to the given channel, etc.
-  pub fn start(config: ClientConfig, tx: Sender<Result<T, ClientError>>) -> Result<Self, Box<dyn Error>> {
-    // TODO: client errors
-    let auth_key = CString::new(config.auth_key)?;
-    let publish_key = CString::new(config.publish_key)?;
-    let subscribe_key = CString::new(config.subscribe_key)?;
-    let channel = CString::new(config.channel)?;
-    let group = CString::new(config.group)?;
-    let client_uuid = CString::new(config.client_uuid)?;
-
-    let user_data = Box::into_raw(Box::new(SubscribeUserData {
-      tx,
-      channel: channel.clone(),
-    }));
-
-    let ctx = unsafe {
-      let ctx = pubnub_alloc();
-      pubnub_init(ctx, publish_key.as_ptr(), subscribe_key.as_ptr());
-      pubnub_set_uuid(ctx, client_uuid.as_ptr());
-      pubnub_set_auth(ctx, auth_key.as_ptr());
-      pubnub_register_callback(ctx, Some(subscribe_callback::<T>), user_data as *mut std::ffi::c_void);
-      pubnub_subscribe(ctx, channel.as_ptr(), std::ptr::null());
-      ctx
-    };
-
-    // TODO: verify that I'm not invalidating the above pointers at this point.
-    Ok(Self {
-      ctx,
-      _channel: channel,
-      _auth_key: auth_key,
-      _publish_key: publish_key,
-      _subscribe_key: subscribe_key,
-      _group: group,
-      _client_uuid: client_uuid,
-      user_data,
-    })
-  }
-}
-
-impl<T> Drop for SubscribeClient<T> {
+impl<T> Drop for Subscription<T> {
   fn drop(&mut self) {
     unsafe {
       pubnub_free(self.ctx);
       Box::from_raw(self.user_data); // This should be safe because we have cleared the mutable ref held by self.ctx
     };
-  }
-}
-
-// TODO: have a single client.
-pub struct PublishClient {
-  // We pass refs of these to C land.  We keep them around here so they will not be freed until the `Client` is dropped.
-  channel: CString,
-  auth_key: CString,
-  publish_key: CString,
-  subscribe_key: CString,
-  group: CString,
-  client_uuid: CString,
-}
-
-impl PublishClient {
-  /// Starts a client, subscribed to the given channel, etc.
-  pub fn new(config: ClientConfig) -> Result<Self, Box<dyn Error>> {
-    // TODO: client errors
-    let auth_key = CString::new(config.auth_key)?;
-    let publish_key = CString::new(config.publish_key)?;
-    let subscribe_key = CString::new(config.subscribe_key)?;
-    let channel = CString::new(config.channel)?;
-    let group = CString::new(config.group)?;
-    let client_uuid = CString::new(config.client_uuid)?;
-
-    Ok(Self {
-      channel,
-      auth_key,
-      publish_key,
-      subscribe_key,
-      group,
-      client_uuid,
-    })
-  }
-
-  pub fn publish<U: Serialize>(&mut self, msg: U) -> PublishFuture {
-    PublishFuture::new(
-      msg,
-      self.channel.clone(),       // TODO: avoid the clone
-      self.auth_key.clone(),      // TODO: avoid the clone
-      self.publish_key.clone(),   // TODO: avoid the clone
-      self.subscribe_key.clone(), // TODO: avoid the clone
-      self.group.clone(),         // TODO: avoid the clone
-      self.client_uuid.clone(),   // TODO: avoid the clone
-    )
   }
 }
 
@@ -205,22 +243,14 @@ pub struct PublishFuture {
 }
 
 impl PublishFuture {
-  fn new<T: Serialize>(
-    msg: T,
-    channel: CString,
-    auth_key: CString,
-    publish_key: CString,
-    subscribe_key: CString,
-    group: CString,
-    client_uuid: CString,
-  ) -> Self {
+  fn new<T: Serialize>(config: ChannelConfig, msg: T) -> Self {
     let msg_string = serde_json::to_string(&msg).unwrap();
     let msg_c = CString::new(msg_string).unwrap();
     let ctx = unsafe {
       let ctx = pubnub_alloc();
-      pubnub_init(ctx, publish_key.as_ptr(), subscribe_key.as_ptr());
-      pubnub_set_uuid(ctx, client_uuid.as_ptr());
-      pubnub_set_auth(ctx, auth_key.as_ptr());
+      pubnub_init(ctx, config.publish_key.as_ptr(), config.subscribe_key.as_ptr());
+      pubnub_set_uuid(ctx, config.client_uuid.as_ptr());
+      pubnub_set_auth(ctx, config.auth_key.as_ptr());
       ctx
     };
 
@@ -229,12 +259,12 @@ impl PublishFuture {
       user_data: None,
       rx: None,
       ctx,
-      channel,
-      _auth_key: auth_key,
-      _publish_key: publish_key,
-      _subscribe_key: subscribe_key,
-      _group: group,
-      _client_uuid: client_uuid,
+      channel: config.channel,
+      _auth_key: config.auth_key,
+      _publish_key: config.publish_key,
+      _subscribe_key: config.subscribe_key,
+      _group: config.group,
+      _client_uuid: config.client_uuid,
       msg: msg_c,
     }
   }
@@ -311,6 +341,7 @@ impl std::error::Error for ClientError {
     }
   }
 }
+
 #[derive(Debug)]
 pub struct JsonError {
   err: serde_json::Error,

--- a/zugzug-sys/build.rs
+++ b/zugzug-sys/build.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use ruplacer::{query::Query, DirectoryPatcher};
 
 use std::env;
-use std::fs::{create_dir, copy, remove_dir_all};
+use std::fs::{copy, create_dir, remove_dir_all};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -22,11 +22,16 @@ fn main() {
 
   let upstream_build_dir_posix = upstream_build_dir.join("posix");
 
-  copy_items(&vec!["vendor/c-core"], &upstream_build_dir.display().to_string(), &CopyOptions {
-    copy_inside: true,
-    overwrite: true,
-    ..CopyOptions::new()
-  }).unwrap();
+  copy_items(
+    &vec!["vendor/c-core"],
+    &upstream_build_dir.display().to_string(),
+    &CopyOptions {
+      copy_inside: true,
+      overwrite: true,
+      ..CopyOptions::new()
+    },
+  )
+  .unwrap();
 
   DirectoryPatcher::new(upstream_build_dir_posix.join("posix.mk"), Default::default())
     .patch(&Query::Regex(
@@ -56,7 +61,11 @@ fn main() {
   {
     #[cfg(feature = "static")]
     {
-      copy(upstream_build_dir_posix.join("pubnub_callback.a"), upstream_build_dir_posix.join("libpubnub_callback.a")).unwrap();
+      copy(
+        upstream_build_dir_posix.join("pubnub_callback.a"),
+        upstream_build_dir_posix.join("libpubnub_callback.a"),
+      )
+      .unwrap();
       println!("cargo:rustc-link-lib=static=pubnub_callback");
     }
 
@@ -82,7 +91,11 @@ fn main() {
   {
     #[cfg(feature = "static")]
     {
-      copy(upstream_build_dir_posix.join("pubnub_sync.a"), upstream_build_dir_posix.join("libpubnub_sync.a")).unwrap();
+      copy(
+        upstream_build_dir_posix.join("pubnub_sync.a"),
+        upstream_build_dir_posix.join("libpubnub_sync.a"),
+      )
+      .unwrap();
       println!("cargo:rustc-link-lib=static=pubnub_sync");
     }
 

--- a/zugzug-sys/build.rs
+++ b/zugzug-sys/build.rs
@@ -65,6 +65,7 @@ fn main() {
     .clang_arg(format!("-I{}", upstream_build_dir.display()))
     .clang_arg(format!("-I{}", upstream_build_dir_posix.display()))
     .clang_arg("-DPUBNUB_CALLBACK_API=1")
+    .clang_arg("-DPUBNUB_THREADSAFE=1") // Makes contexts thread-safe, justifying our making them Send and Sync.
     .blacklist_function("strtold") // u128 is not ffi-safe
     .generate()
     .expect("Unable to generate callback bindings");

--- a/zugzug-sys/build.rs
+++ b/zugzug-sys/build.rs
@@ -12,7 +12,6 @@ fn main() {
 
   // TODO: cross compile
   // TODO: use variables for paths, etc.
-  // TODO: make this stuff more portable (e.g. no `Command`)
   let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
   remove_dir_all(&out_path).unwrap();


### PR DESCRIPTION
Changes api to a single client which returns `Stream`s and `Future`s on subscribe and publish respectively.