### PR TITLE
Query system for DNS server correctly

### DIFF
--- a/zugzug-sys/build.rs
+++ b/zugzug-sys/build.rs
@@ -114,4 +114,19 @@ fn main() {
     #[cfg(feature = "dynamic")]
     println!("cargo:rustc-link-lib=pubnub_sync");
   }
+
+  let dns_bindings = bindgen::Builder::default()
+  .header(format!("{}/core/pubnub_dns_servers.h", upstream_build_dir.display()))
+  .clang_arg(format!("-I{}", upstream_build_dir.display()))
+  .clang_arg(format!("-I{}", upstream_build_dir_posix.display()))
+  .clang_arg("-DPUBNUB_CALLBACK_API=1")
+  .clang_arg("-DPUBNUB_SET_DNS_SERVERS=1")
+  .clang_arg("-DPUBNUB_THREADSAFE=1") // Makes contexts thread-safe, justifying our making them Send and Sync.
+  .blacklist_function("strtold") // u128 is not ffi-safe
+  .generate()
+  .expect("Unable to generate dns bindings");
+
+  dns_bindings
+    .write_to_file(out_path.join("dns.rs"))
+    .expect("Couldn't write bindings");
 }

--- a/zugzug-sys/src/lib.rs
+++ b/zugzug-sys/src/lib.rs
@@ -18,6 +18,15 @@ pub mod sync {
   include!(concat!(env!("OUT_DIR"), "/sync.rs"));
 }
 
+#[allow(non_upper_case_globals)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+#[allow(clippy::all)]
+pub mod dns {
+  include!(concat!(env!("OUT_DIR"), "/dns.rs"));
+}
+
 #[cfg(test)]
 #[cfg(feature = "sync")]
 mod sync_test {


### PR DESCRIPTION
zugzug currently uses DNS server 8.8.8.8 for DNS queries, this fixes it to query the system before making calls.